### PR TITLE
Incorporate Flex cmake as build module

### DIFF
--- a/recipes/flex/all/conan-official-flex-macros.cmake
+++ b/recipes/flex/all/conan-official-flex-macros.cmake
@@ -1,0 +1,156 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+find_program(FLEX_EXECUTABLE NAMES flex win-flex win_flex DOC "path to the flex executable")
+mark_as_advanced(FLEX_EXECUTABLE)
+
+find_library(FL_LIBRARY NAMES fl
+  DOC "Path to the fl library")
+
+find_path(FLEX_INCLUDE_DIR FlexLexer.h
+  DOC "Path to the flex headers")
+
+mark_as_advanced(FL_LIBRARY FLEX_INCLUDE_DIR)
+
+set(FLEX_INCLUDE_DIRS ${FLEX_INCLUDE_DIR})
+set(FLEX_LIBRARIES ${FL_LIBRARY})
+
+if(FLEX_EXECUTABLE)
+
+  execute_process(COMMAND ${FLEX_EXECUTABLE} --version
+    OUTPUT_VARIABLE FLEX_version_output
+    ERROR_VARIABLE FLEX_version_error
+    RESULT_VARIABLE FLEX_version_result
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  if(NOT ${FLEX_version_result} EQUAL 0)
+    if(FLEX_FIND_REQUIRED)
+      message(SEND_ERROR "Command \"${FLEX_EXECUTABLE} --version\" failed with output:\n${FLEX_version_output}\n${FLEX_version_error}")
+    else()
+      message("Command \"${FLEX_EXECUTABLE} --version\" failed with output:\n${FLEX_version_output}\n${FLEX_version_error}\nFLEX_VERSION will not be available")
+    endif()
+  else()
+    # older versions of flex printed "/full/path/to/executable version X.Y"
+    # newer versions use "basename(executable) X.Y"
+    get_filename_component(FLEX_EXE_NAME_WE "${FLEX_EXECUTABLE}" NAME_WE)
+    get_filename_component(FLEX_EXE_EXT "${FLEX_EXECUTABLE}" EXT)
+    string(REGEX REPLACE "^.*${FLEX_EXE_NAME_WE}(${FLEX_EXE_EXT})?\"? (version )?([0-9]+[^ ]*)( .*)?$" "\\3"
+      FLEX_VERSION "${FLEX_version_output}")
+    unset(FLEX_EXE_EXT)
+    unset(FLEX_EXE_NAME_WE)
+  endif()
+
+  #============================================================
+  # FLEX_TARGET (public macro)
+  #============================================================
+  #
+  macro(FLEX_TARGET Name Input Output)
+
+    set(FLEX_TARGET_PARAM_OPTIONS)
+    set(FLEX_TARGET_PARAM_ONE_VALUE_KEYWORDS
+      COMPILE_FLAGS
+      DEFINES_FILE
+      )
+    set(FLEX_TARGET_PARAM_MULTI_VALUE_KEYWORDS)
+
+    cmake_parse_arguments(
+      FLEX_TARGET_ARG
+      "${FLEX_TARGET_PARAM_OPTIONS}"
+      "${FLEX_TARGET_PARAM_ONE_VALUE_KEYWORDS}"
+      "${FLEX_TARGET_MULTI_VALUE_KEYWORDS}"
+      ${ARGN}
+      )
+
+    set(FLEX_TARGET_usage "FLEX_TARGET(<Name> <Input> <Output> [COMPILE_FLAGS <string>] [DEFINES_FILE <string>]")
+
+    if(NOT "${FLEX_TARGET_ARG_UNPARSED_ARGUMENTS}" STREQUAL "")
+      message(SEND_ERROR ${FLEX_TARGET_usage})
+    else()
+
+      cmake_policy(GET CMP0098 _flex_CMP0098
+          PARENT_SCOPE # undocumented, do not use outside of CMake
+        )
+      set(_flex_INPUT "${Input}")
+      if("x${_flex_CMP0098}x" STREQUAL "xNEWx")
+        set(_flex_WORKING_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+        if(NOT IS_ABSOLUTE "${_flex_INPUT}")
+          set(_flex_INPUT "${CMAKE_CURRENT_SOURCE_DIR}/${_flex_INPUT}")
+        endif()
+      else()
+        set(_flex_WORKING_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+      endif()
+      unset(_flex_CMP0098)
+
+      set(_flex_OUTPUT "${Output}")
+      if(NOT IS_ABSOLUTE ${_flex_OUTPUT})
+        set(_flex_OUTPUT "${_flex_WORKING_DIR}/${_flex_OUTPUT}")
+      endif()
+      set(_flex_TARGET_OUTPUTS "${_flex_OUTPUT}")
+
+      set(_flex_EXE_OPTS "")
+      if(NOT "${FLEX_TARGET_ARG_COMPILE_FLAGS}" STREQUAL "")
+        set(_flex_EXE_OPTS "${FLEX_TARGET_ARG_COMPILE_FLAGS}")
+        separate_arguments(_flex_EXE_OPTS)
+      endif()
+
+      set(_flex_OUTPUT_HEADER "")
+      if(NOT "${FLEX_TARGET_ARG_DEFINES_FILE}" STREQUAL "")
+        set(_flex_OUTPUT_HEADER "${FLEX_TARGET_ARG_DEFINES_FILE}")
+        if(IS_ABSOLUTE "${_flex_OUTPUT_HEADER}")
+          set(_flex_OUTPUT_HEADER_ABS "${_flex_OUTPUT_HEADER}")
+        else()
+          set(_flex_OUTPUT_HEADER_ABS "${_flex_WORKING_DIR}/${_flex_OUTPUT_HEADER}")
+        endif()
+        list(APPEND _flex_TARGET_OUTPUTS "${_flex_OUTPUT_HEADER_ABS}")
+        list(APPEND _flex_EXE_OPTS --header-file=${_flex_OUTPUT_HEADER_ABS})
+      endif()
+
+      get_filename_component(_flex_EXE_NAME_WE "${FLEX_EXECUTABLE}" NAME_WE)
+      add_custom_command(OUTPUT ${_flex_TARGET_OUTPUTS}
+        COMMAND ${FLEX_EXECUTABLE} ${_flex_EXE_OPTS} -o${_flex_OUTPUT} ${_flex_INPUT}
+        VERBATIM
+        DEPENDS ${_flex_INPUT}
+        COMMENT "[FLEX][${Name}] Building scanner with ${_flex_EXE_NAME_WE} ${FLEX_VERSION}"
+        WORKING_DIRECTORY ${_flex_WORKING_DIR})
+
+      set(FLEX_${Name}_DEFINED TRUE)
+      set(FLEX_${Name}_OUTPUTS ${_flex_TARGET_OUTPUTS})
+      set(FLEX_${Name}_INPUT ${_flex_INPUT})
+      set(FLEX_${Name}_COMPILE_FLAGS ${_flex_EXE_OPTS})
+      set(FLEX_${Name}_OUTPUT_HEADER ${_flex_OUTPUT_HEADER})
+
+      unset(_flex_EXE_NAME_WE)
+      unset(_flex_EXE_OPTS)
+      unset(_flex_INPUT)
+      unset(_flex_OUTPUT)
+      unset(_flex_OUTPUT_HEADER)
+      unset(_flex_OUTPUT_HEADER_ABS)
+      unset(_flex_TARGET_OUTPUTS)
+      unset(_flex_WORKING_DIR)
+
+    endif()
+  endmacro()
+  #============================================================
+
+
+  #============================================================
+  # ADD_FLEX_BISON_DEPENDENCY (public macro)
+  #============================================================
+  #
+  macro(ADD_FLEX_BISON_DEPENDENCY FlexTarget BisonTarget)
+
+    if(NOT FLEX_${FlexTarget}_OUTPUTS)
+      message(SEND_ERROR "Flex target `${FlexTarget}' does not exist.")
+    endif()
+
+    if(NOT BISON_${BisonTarget}_OUTPUT_HEADER)
+      message(SEND_ERROR "Bison target `${BisonTarget}' does not exist.")
+    endif()
+
+    set_source_files_properties(${FLEX_${FlexTarget}_OUTPUTS}
+      PROPERTIES OBJECT_DEPENDS ${BISON_${BisonTarget}_OUTPUT_HEADER})
+  endmacro()
+  #============================================================
+
+endif()
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(FLEX REQUIRED_VARS FLEX_EXECUTABLE VERSION_VAR FLEX_VERSION)

--- a/recipes/flex/all/test_package/CMakeLists.txt
+++ b/recipes/flex/all/test_package/CMakeLists.txt
@@ -1,7 +1,9 @@
 cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES CXX)
 
-find_package(FLEX REQUIRED)
+set(CMAKE_VERBOSE_MAKEFILE ON)
+
+find_package(FLEX CONFIG REQUIRED)
 flex_target(flex_scanner basic_nr.l ${PROJECT_BINARY_DIR}/basic_nr.cpp)
 
 add_executable(${PROJECT_NAME} basic_nr.cpp)

--- a/recipes/flex/all/test_package/conanfile.py
+++ b/recipes/flex/all/test_package/conanfile.py
@@ -9,7 +9,7 @@ from conan.tools.cmake import CMake, cmake_layout
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeToolchain", "VirtualBuildEnv", "VirtualRunEnv"
+    generators = "CMakeToolchain", "VirtualBuildEnv", "VirtualRunEnv", "CMakeDeps"
     test_type = "explicit"
 
     def requirements(self):
@@ -29,7 +29,7 @@ class TestPackageConan(ConanFile):
 
         output = StringIO()
         self.run("flex --version", output)
-        output_str = str(output.getvalue()) 
+        output_str = str(output.getvalue())
         self.output.info("Installed version: {}".format(output_str))
         expected_version = tested_reference_version()
         self.output.info("Expected version: {}".format(expected_version))


### PR DESCRIPTION
- Use FindFLEX.cmake provided by CMake as a build module
- Load first those targets and variables generated by FindFLEX.cmake (CMakeDeps)
- Then, load to the original one

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
